### PR TITLE
support R >= 2.14.0 only

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: The tikzDevice package provides a graphics output device for R
     LaTeX code to be inserted into the output stream.
 License: GPL (>= 2)
 Depends:
-    R (>= 2.12.0),
+    R (>= 2.14.0),
     filehash
 Suggests:
     testthat (>= 0.6),

--- a/inst/tests/test_graphics.R
+++ b/inst/tests/test_graphics.R
@@ -443,16 +443,6 @@ test_graphs <- list(
     short_name = 'raster_reflection',
     description = 'Test raster handling in graphics with reflected axes',
     tags = c('base', 'raster'),
-    # R 2.12.0 does not support the `useRaster` argumet to `image`.
-    #
-    # NOTE:
-    # Interestingly, calling this test with `useRaster=FALSE` appears to create
-    # a graph that causes pdfTeX to exceed its memory capacity. LuaLaTeX
-    # handles it like a champ and doesn't even allocate 100 MB of memory. Takes
-    # a while to compute.  Could be a good candidate for optimization.
-    #
-    # FIXME: Remove once we drop support for 2.12.x
-    skip_if = function() { getRversion() < "2.13.0" },
     graph_code = quote({
 
       par(mfrow = c(2,2))

--- a/tests/unit_tests.R
+++ b/tests/unit_tests.R
@@ -32,16 +32,7 @@ if (nchar(Sys.getenv('R_TESTS')) == 0){
   options(tikzMetricsDictionary = NULL)
 
   expand_test_path <- function(path) {
-    call_args = list(path = path)
-    if( getRversion() >= '2.13.0' ) {
-      # After R 2.13.0, normalizePath bitches and moans if the path does not
-      # exist. Squelch this warning.
-      #
-      # FIXME: Remove this once we drop support for R 2.12.x
-      call_args[['mustWork']] = FALSE
-    }
-
-    do.call(normalizePath, call_args)
+    normalizePath(path, mustWork = FALSE)
   }
 
   # Set up directories for test output.


### PR DESCRIPTION
Testing R 2.13 and below is a real pain:
- essential packages require R 2.14 in their current version
- no support for `Authors@R`
- other nuisances

Fixes #9.
