### PR TITLE
Loading babel TeX package to avoid printing tilde in references

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -77,7 +77,6 @@ news:
 vignette:
 	cd vignettes;\
 		"$(RBIN)/R" CMD Sweave --pdf $(PKGNAME).Rnw;\
-		pdflatex $(PKGNAME).tex;\
 		"$(RBIN)/R" --vanilla --slave -e "tools:::compactPDF(getwd(), gs_quality='printer')"
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - Vignette now also compiles if the zi4 TeX package is installed instead of
   inconsolata.  This should fix the CRAN notes and warnings on Windows.
 
+- Loading babel TeX package to avoid printing tilde in references (#49).
+
 ---
 
 # Changes in version 0.7.0 (2013-12-10, CRAN release)

--- a/vignettes/tikzDeviceVignette.sty
+++ b/vignettes/tikzDeviceVignette.sty
@@ -34,6 +34,7 @@
 % Bibliography
 \RequirePackage{natbib}
 \bibliographystyle{agufull04}
+\RequirePackage[english]{babel}
 
 \RequirePackage[nogin,noae]{Sweave}
 % Extra pretty pretty printing.


### PR DESCRIPTION
Surprisingly, this fixes the tilde introduced by texi2pdf for cross references
and "et al.".

https://stat.ethz.ch/pipermail/r-devel/2012-January/063084.html

Linked from there, especially useful:
http://www2.it.lut.fi/wiki/doku.php/common/latex_hints
