### PR TITLE
remove the alias definition for symbolic color names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 ## Features
+
 - Remove redefinition of `fillColor` and `drawColor` when symbolic color names
   are used.
+
+## Bug Fixes
+
+ - Do not create color file if `tikzSymbolicColors` is off
+ - Fix issue with translating color with representation -1
 
 ---
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## Features
+- Remove redefinition of `fillColor` and `drawColor` when symbolic color names
+  are used.
+
 ---
 
 # Changes in version 0.7.4 (2014-11-10)

--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -306,6 +306,10 @@ static Rboolean TikZ_Setup(
   tikzInfo->onefile = onefile;
   tikzInfo->pageNum = 1;
 
+  /* initialize strings, just to be on the safe side */
+  strcpy(tikzInfo->drawColor, "drawColor");
+  strcpy(tikzInfo->fillColor, "fillColor");
+
   /* Incorporate tikzInfo into deviceInfo. */
   deviceInfo->deviceSpecific = (void *) tikzInfo;
 
@@ -508,13 +512,6 @@ static Rboolean TikZ_Setup(
 static void TikZ_WriteColorDefinition( tikzDevDesc *tikzInfo, void (*printOut)(tikzDevDesc *tikzInfo, const char *format, ...), int color, const char* colorname, const char* colorstr )
 {
 
-  /* strip # from both strings as they are not necessary nor allowed */
-  if( colorname[0] == '#' )
-    colorname= colorname +1;
-
-  if( colorstr[0] == '#')
-    colorstr = colorstr+1;
-
   /* define the color as an alias */
   if( color == -1 )
     printOutput(tikzInfo,
@@ -546,6 +543,10 @@ static void TikZ_WriteColorDefinitions( tikzDevDesc *tikzInfo )
   for( i = 0; i < tikzInfo->ncolors; ++i)
   {
     const char* colorstr = col2name(tikzInfo->colors[i]);
+
+    if(colorstr[0] == '#')
+      colorstr = colorstr+1;
+
     TikZ_WriteColorDefinition(tikzInfo, printColorOutput, tikzInfo->colors[i], colorstr, colorstr);
   }
 }
@@ -1153,7 +1154,7 @@ static void TikZ_Text( double x, double y, const char *str,
   TikZ_DefineColors(plotParams, deviceInfo, DRAWOP_DRAW);
 
   /* Start a node for the text, open an options bracket. */
-  printOutput(tikzInfo,"\n\\node[text=drawColor");
+  printOutput(tikzInfo,"\n\\node[text=%s", tikzInfo->drawColor);
   /* FIXME: Should bail out of this function early if text is fully transparent */
   if( !R_OPAQUE(plotParams->col) )
     printOutput(tikzInfo, ",text opacity=%4.2f", R_ALPHA(plotParams->col)/255.0);
@@ -1787,14 +1788,35 @@ static Rboolean TikZ_CheckAndAddColor(tikzDevDesc *tikzInfo, int color)
   return colorfound;
 }
 
-static void TikZ_DefineDrawColor(tikzDevDesc *tikzInfo, int color, const char* colortype)
+static void TikZ_DefineDrawColor(tikzDevDesc *tikzInfo, int color, TikZ_DrawOps ops)
 {
   const char *colorstr = col2name(color);
+  const char* colors[] = {"", "drawColor", "fillColor"};
+  char* dest;
+
+  if( colorstr[0] == '#' )
+    colorstr = colorstr+1;
+
+  if( ops == DRAWOP_DRAW)
+  {
+    dest = tikzInfo->drawColor;
+  }
+  else if( ops == DRAWOP_FILL )
+  {
+    dest = tikzInfo->fillColor;
+  }
 
   if( TikZ_CheckAndAddColor(tikzInfo, color) )
-    TikZ_WriteColorDefinition(tikzInfo, printOutput, -1, colortype, colorstr);
+  {
+    strlcpy(dest, colorstr, strlen(colorstr));
+  }
   else
-    TikZ_WriteColorDefinition(tikzInfo, printOutput, color, colortype, colorstr);
+  {
+    strlcpy(dest, colors[ops], strlen(colorstr));
+
+    TikZ_WriteColorDefinition(tikzInfo, printOutput, color, colors[ops], colorstr);
+  }
+
 
 }
 
@@ -1805,10 +1827,9 @@ static void TikZ_DefineColors(pGEcontext plotParams, pDevDesc deviceInfo, TikZ_D
 
   if ( ops & DRAWOP_DRAW ) {
     color = plotParams->col;
-
     if ( color != tikzInfo->oldDrawColor ) {
       tikzInfo->oldDrawColor = color;
-      TikZ_DefineDrawColor(tikzInfo, color, "drawColor");
+      TikZ_DefineDrawColor(tikzInfo, color, DRAWOP_DRAW);
     }
   }
 
@@ -1816,7 +1837,7 @@ static void TikZ_DefineColors(pGEcontext plotParams, pDevDesc deviceInfo, TikZ_D
     color = plotParams->fill;
     if( color != tikzInfo->oldFillColor ) {
       tikzInfo->oldFillColor = color;
-      TikZ_DefineDrawColor(tikzInfo, color, "fillColor");
+      TikZ_DefineDrawColor(tikzInfo, color, DRAWOP_FILL);
     }
   }
 
@@ -1838,7 +1859,7 @@ static void TikZ_WriteDrawOptions(const pGEcontext plotParams, pDevDesc deviceIn
   tikzDevDesc *tikzInfo = (tikzDevDesc *) deviceInfo->deviceSpecific;
 
   if ( ops & DRAWOP_DRAW ) {
-    printOutput(tikzInfo, "draw=drawColor");
+    printOutput(tikzInfo, "draw=%s", tikzInfo->drawColor);
     if( !R_OPAQUE(plotParams->col) )
       printOutput(tikzInfo, ",draw opacity=%4.2f", R_ALPHA(plotParams->col)/255.0);
 
@@ -1850,7 +1871,7 @@ static void TikZ_WriteDrawOptions(const pGEcontext plotParams, pDevDesc deviceIn
     if ( ops & DRAWOP_DRAW )
       printOutput(tikzInfo, ",");
 
-    printOutput(tikzInfo, "fill=fillColor");
+    printOutput(tikzInfo, "fill=%s", tikzInfo->fillColor);
     if( !R_OPAQUE(plotParams->fill) )
       printOutput(tikzInfo, ",fill opacity=%4.2f", R_ALPHA(plotParams->fill)/255.0);
   }
@@ -2259,12 +2280,12 @@ static void TikZ_CheckState(pDevDesc deviceInfo)
      */
     int color = deviceInfo->startfill;
     tikzInfo->oldFillColor = color;
-    TikZ_DefineDrawColor(tikzInfo, color, "fillColor");
+    TikZ_DefineDrawColor(tikzInfo, color, DRAWOP_FILL);
 
     printOutput(tikzInfo, "\\path[use as bounding box");
 
     /* TODO: Consider only filling when the color is not transparent. */
-    printOutput(tikzInfo, ",fill=fillColor");
+    printOutput(tikzInfo, ",fill=%s", tikzInfo->fillColor);
     if( !R_OPAQUE(color) )
       printOutput(tikzInfo, ",fill opacity=%4.2f", R_ALPHA(color)/255.0);
 

--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -512,13 +512,7 @@ static Rboolean TikZ_Setup(
 static void TikZ_WriteColorDefinition( tikzDevDesc *tikzInfo, void (*printOut)(tikzDevDesc *tikzInfo, const char *format, ...), int color, const char* colorname, const char* colorstr )
 {
 
-  /* define the color as an alias */
-  if( color == -1 )
-    printOutput(tikzInfo,
-      "\\definecolor{%s}{named}{%s}\n",
-      colorname, colorstr);
-  /* treat gray colors separately */
-  else if ( strncmp(colorstr, "gray", 4) == 0 && strlen(colorstr) > 4)
+  if ( strncmp(colorstr, "gray", 4) == 0 && strlen(colorstr) > 4)
   {
     int perc = atoi(colorstr+4);
     printOut(tikzInfo,

--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -547,7 +547,7 @@ static void TikZ_WriteColorDefinitions( tikzDevDesc *tikzInfo )
 
 static void TikZ_WriteColorFile(tikzDevDesc *tikzInfo)
 {
-  if ( tikzInfo->outColorFileName )
+  if ( tikzInfo->outColorFileName && tikzInfo->symbolicColors )
   {
     tikzInfo->colorFile = fopen(R_ExpandFileName(tikzInfo->outColorFileName), "w");
     if( tikzInfo->colorFile)
@@ -1802,11 +1802,11 @@ static void TikZ_DefineDrawColor(tikzDevDesc *tikzInfo, int color, TikZ_DrawOps 
 
   if( TikZ_CheckAndAddColor(tikzInfo, color) )
   {
-    strlcpy(dest, colorstr, strlen(colorstr));
+    strlcpy(dest, colorstr, strlen(colorstr)+1);
   }
   else
   {
-    strlcpy(dest, colors[ops], strlen(colorstr));
+    strlcpy(dest, colors[ops], strlen(colors[ops])+1);
 
     TikZ_WriteColorDefinition(tikzInfo, printOutput, color, colors[ops], colorstr);
   }
@@ -2327,4 +2327,20 @@ static char *calloc_x_strlen(const char *str, size_t extra){
 
 static void const_free(const void *ptr){
   free((void*)ptr);
+}
+
+static size_t strlcpy(char *dst, const char* src, size_t n){
+  size_t size = strlen(src);
+  size_t newsize = n;
+
+  if( newsize == 0)
+    return newsize;
+
+  if( newsize > size )
+    newsize = size;
+
+  strncpy(dst, src, newsize);
+  dst[newsize] = '\0';
+
+  return newsize;
 }

--- a/src/tikzDevice.h
+++ b/src/tikzDevice.h
@@ -207,5 +207,5 @@ static char *calloc_strcpy(const char *str);
 static char *calloc_x_strcpy(const char *str, size_t extra);
 static char *calloc_x_strlen(const char *str, size_t extra);
 static void const_free(const void *ptr);
-
+static size_t strlcpy(char *dst, const char* src, size_t n);
 #endif // End of Once Only header

--- a/src/tikzDevice.h
+++ b/src/tikzDevice.h
@@ -88,6 +88,8 @@ typedef struct {
   int ncolors;
   int maxSymbolicColors;
   Rboolean excessWarningPrinted;
+  char drawColor[128];
+  char fillColor[128];
 } tikzDevDesc;
 
 


### PR DESCRIPTION
When using symbolic color names, we can drop the redefinition of the fill and draw colors.

This greatly reduces the file size. A fallback mechanism ensures the definitions are done as usual if either

 1. the maximal number of colors are exhausted or
 1. symbolic color names are switched off.