### PR TITLE
fixes #63: ignore fill color in order to draw lines correctly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## Bug fixes
+
+ - Ignore fill color for lines to draw them correctly (#63)
+
 ---
 
 # Changes in version 0.7.4 (2014-11-10)

--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -1271,7 +1271,7 @@ static void TikZ_Line( double x1, double y1,
 
   /* Shortcut pointers to variables of interest. */
   tikzDevDesc *tikzInfo = (tikzDevDesc *) deviceInfo->deviceSpecific;
-  TikZ_DrawOps ops = TikZ_GetDrawOps(plotParams);
+  TikZ_DrawOps ops = TikZ_GetDrawOps(plotParams) & DRAWOP_DRAW;
 
   /*Show only for debugging*/
   if(tikzInfo->debug == TRUE)


### PR DESCRIPTION
The fix for #63, very simple but effective.