### PR TITLE
rename strlcpy to strlcpy_ to avoid conflicts on OS X and Solaris

### DIFF
--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -2335,7 +2335,7 @@ static void const_free(const void *ptr){
   free((void*)ptr);
 }
 
-static void strlcpy(char *dst, const char* src, size_t n){
+static void strlcpy_(char *dst, const char* src, size_t n){
   if (n <= 0) return;
   strncpy(dst, src, n - 1);
   dst[n - 1] = '\0';

--- a/src/tikzDevice.h
+++ b/src/tikzDevice.h
@@ -209,6 +209,6 @@ static char *calloc_strcpy(const char *str);
 static char *calloc_x_strcpy(const char *str, size_t extra);
 static char *calloc_x_strlen(const char *str, size_t extra);
 static void const_free(const void *ptr);
-static void strlcpy(char *dst, const char* src, size_t n);
-#define strscpy(dst, src) strlcpy(dst, src, sizeof(dst) / sizeof(*(dst)))
+static void strlcpy_(char *dst, const char* src, size_t n);
+#define strscpy(dst, src) strlcpy_(dst, src, sizeof(dst) / sizeof(*(dst)))
 #endif // End of Once Only header


### PR DESCRIPTION
Fixes #97.