### PR TITLE
Fix issue with encoding on Windows (foreign characters)

### DIFF
--- a/R/latexStrWidth.R
+++ b/R/latexStrWidth.R
@@ -393,9 +393,8 @@ function( TeXMetrics ){
   close( texIn )
   
   if (grepl("1251",Sys.getlocale("LC_CTYPE"))) {
-    fileEncoded <- scan(texFile,what=character(),encoding="CP1251",sep="\n")
-    fileReEncoded <- iconv(fileEncoded,from="CP1251",to="UTF8")
-    writeLines(fileReEncoded,texFile)
+    texIn <- scan(texFile,what=character(),encoding="CP1251",sep="\n")
+    write.table(texIn,file=texFile,fileEncoding="UTF-8",row.names=FALSE,col.names=FALSE,quote=FALSE)
   }
 
   # Recover the latex command. Use XeLaTeX if the character is not ASCII

--- a/R/latexStrWidth.R
+++ b/R/latexStrWidth.R
@@ -391,6 +391,12 @@ function( TeXMetrics ){
 
   # Close the LaTeX file, ready to compile
   close( texIn )
+  
+  if (grepl("1251",Sys.getlocale("LC_CTYPE"))) {
+    fileEncoded <- scan(texFile,what=character(),encoding="CP1251",sep="\n")
+    fileReEncoded <- iconv(fileEncoded,from="CP1251",to="UTF8")
+    writeLines(fileReEncoded,texFile)
+  }
 
   # Recover the latex command. Use XeLaTeX if the character is not ASCII
   latexCmd <- switch(TeXMetrics$engine,

--- a/R/tikzInternal.R
+++ b/R/tikzInternal.R
@@ -1,6 +1,14 @@
 # These are unexported functions that are called by the C routines of the tikz
 # device to execute tasks that are difficult to do at the C level.
 
+enc1251toUTF8 <- function(fileName){
+    if (grepl("1251",Sys.getlocale("LC_CTYPE"))) {
+       fileEncoded <- scan(fileName,what=character(),encoding="CP1251",sep="\n")
+       fileReEncoded <- iconv(fileEncoded,from="CP1251",to="UTF8")
+       writeLines(fileReEncoded,fileName)
+    }
+}
+
 getDateStampForTikz <- function(){
 
   # This function retrieves the current date stamp using

--- a/R/tikzInternal.R
+++ b/R/tikzInternal.R
@@ -3,9 +3,8 @@
 
 enc1251toUTF8 <- function(fileName){
     if (grepl("1251",Sys.getlocale("LC_CTYPE"))) {
-       fileEncoded <- scan(fileName,what=character(),encoding="CP1251",sep="\n")
-       fileReEncoded <- iconv(fileEncoded,from="CP1251",to="UTF8")
-       writeLines(fileReEncoded,fileName)
+        fileEncoded <- scan(fileName,what=character(),encoding="CP1251",sep="\n")
+        write.table(fileEncoded,file=fileName,fileEncoding="UTF-8",row.names=FALSE,col.names=FALSE,quote=FALSE)
     }
 }
 

--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -673,7 +673,7 @@ static void TikZ_Close( pDevDesc deviceInfo)
     SEXP e, tmp, ret,myNamespace;
     PROTECT( myNamespace = TIKZ_NAMESPACE );
     PROTECT(e = allocVector(LANGSXP, 2));
-    tmp = findFun(install("encodingConvert"), myNamespace);
+    tmp = findFun(install("enc1251toUTF8"), myNamespace);
     SETCAR(e, tmp);
     SETCADR(e, mkString(tikzInfo->outFileName));
     PROTECT(ret = R_tryEval(e, myNamespace, NULL));
@@ -723,7 +723,7 @@ static void TikZ_NewPage( const pGEcontext plotParams, pDevDesc deviceInfo )
         fclose(tikzInfo->outputFile);
         PROTECT( myNamespace = TIKZ_NAMESPACE );
         PROTECT(e = allocVector(LANGSXP, 2));
-        tmp = findFun(install("encodingConvert"), myNamespace);
+        tmp = findFun(install("enc1251toUTF8"), myNamespace);
         SETCAR(e, tmp);
         SETCADR(e, mkString(tikzInfo->outFileName));
         PROTECT(ret = R_tryEval(e, myNamespace, NULL));

--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -670,7 +670,7 @@ static void TikZ_Close( pDevDesc deviceInfo)
   if(tikzInfo->console == FALSE)
   {
     fclose(tikzInfo->outputFile);
-    SEXP e, tmp, ret,myNamespace;
+    SEXP e, tmp, ret, myNamespace;
     PROTECT( myNamespace = TIKZ_NAMESPACE );
     PROTECT(e = allocVector(LANGSXP, 2));
     tmp = findFun(install("enc1251toUTF8"), myNamespace);
@@ -721,6 +721,7 @@ static void TikZ_NewPage( const pGEcontext plotParams, pDevDesc deviceInfo )
 
       if( !tikzInfo->console )
         fclose(tikzInfo->outputFile);
+        SEXP e, tmp, ret, myNamespace;
         PROTECT( myNamespace = TIKZ_NAMESPACE );
         PROTECT(e = allocVector(LANGSXP, 2));
         tmp = findFun(install("enc1251toUTF8"), myNamespace);

--- a/src/tikzDevice.c
+++ b/src/tikzDevice.c
@@ -670,6 +670,14 @@ static void TikZ_Close( pDevDesc deviceInfo)
   if(tikzInfo->console == FALSE)
   {
     fclose(tikzInfo->outputFile);
+    SEXP e, tmp, ret,myNamespace;
+    PROTECT( myNamespace = TIKZ_NAMESPACE );
+    PROTECT(e = allocVector(LANGSXP, 2));
+    tmp = findFun(install("encodingConvert"), myNamespace);
+    SETCAR(e, tmp);
+    SETCADR(e, mkString(tikzInfo->outFileName));
+    PROTECT(ret = R_tryEval(e, myNamespace, NULL));
+    UNPROTECT(3);
     tikzInfo->outputFile = NULL;
   }
 
@@ -713,6 +721,13 @@ static void TikZ_NewPage( const pGEcontext plotParams, pDevDesc deviceInfo )
 
       if( !tikzInfo->console )
         fclose(tikzInfo->outputFile);
+        PROTECT( myNamespace = TIKZ_NAMESPACE );
+        PROTECT(e = allocVector(LANGSXP, 2));
+        tmp = findFun(install("encodingConvert"), myNamespace);
+        SETCAR(e, tmp);
+        SETCADR(e, mkString(tikzInfo->outFileName));
+        PROTECT(ret = R_tryEval(e, myNamespace, NULL));
+        UNPROTECT(3);
     }
 
     /* write symbolic color names to the corresponding file */


### PR DESCRIPTION
### Genesis

Basically, the issue shows up when one uses foreign characters in tikz annotations on Windows systems with default CP1251 encoding. The problem arises because tex compiler (either pdfTex or XeLaTeX) tries to compile tikz illustrations or main file (when using knitr on rnw files) as UTF-8-encoded, while it is actually CP1251-encoded. It leads to the crash of witdh calculation, and to the crash of main rnw file comiplation. 
### The fix

The conversion function is added to `tikzinternal.R` source file. It can be updated to fix similar issues with other encodings.
I used `write.table()` because `writeLines()` function (combined with `iconv()`) doesn't work properly on Windows machines in this case.
Then two calls to this function are added to the `tikzDevice.c` (right after closing the file), and one, just as source code of the function — to the `latexStrWidth.R`.
This fix solves the issue described above. I tested it on my Windows and Unix (Arch OS) systems.
