### PR TITLE
Add website link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c( person("Charlie", "Sharpsteen", role = "aut"),
         person("Ralf", "Stubner", email = "ralf.stubner@gmail.com", 
         role = "cre"), person("Nico", "Bellack", 
         email = "nico.belack@daqana.com", role = "ctb") ) 
-URL: https://github.com/daqana/tikzDevice
+URL: https://daqana.github.io/tikzDevice/, https://github.com/daqana/tikzDevice
 BugReports: https://github.com/daqana/tikzDevice/issues
 Description: Provides a graphics output device for R that records plots
         in a LaTeX-friendly format. The device transforms plotting


### PR DESCRIPTION
I'd recommend adding a pkgdown gh action as well.

Running this locally should do it:

`usethis::use_pkgdown_github_pages()`